### PR TITLE
Error under RSpec 3

### DIFF
--- a/lib/db_query_matchers/make_database_queries.rb
+++ b/lib/db_query_matchers/make_database_queries.rb
@@ -1,4 +1,6 @@
-require 'rspec'
+require 'rspec/core'
+require 'rspec/expectations'
+require 'rspec/mocks'
 
 # Custom matcher to check for database queries performed by a block of code.
 #


### PR DESCRIPTION
`undefined method`define' for RSpec::Matchers:Module (NoMethodError)`

I am using RSpec 3, Rails 4.1, Ruby 2.1.2
