### PR TITLE
add manipulative option to match CREATE, UPDATE and DELETE FROM queries

### DIFF
--- a/lib/db_query_matchers/make_database_queries.rb
+++ b/lib/db_query_matchers/make_database_queries.rb
@@ -10,6 +10,9 @@ require 'rspec/mocks'
 # @example
 #   expect { subject }.to make_database_queries(count: 1)
 #
+# @example
+#   expect { subject }.to make_database_queries(manipulative: true)
+#
 # @see DBQueryMatchers::QueryCounter
 RSpec::Matchers.define :make_database_queries do |options = {}|
   supports_block_expectations
@@ -26,7 +29,11 @@ RSpec::Matchers.define :make_database_queries do |options = {}|
   end
 
   match do |block|
-    @counter = DBQueryMatchers::QueryCounter.new
+    counter_options = {}
+    if options[:manipulative]
+      counter_options[:matches] = [/^\ *(INSERT|UPDATE|DELETE\ FROM)/]
+    end
+    @counter = DBQueryMatchers::QueryCounter.new(counter_options)
     ActiveSupport::Notifications.subscribed(@counter.to_proc,
                                             'sql.active_record',
                                             &block)

--- a/spec/db_query_matchers/make_database_queries_spec.rb
+++ b/spec/db_query_matchers/make_database_queries_spec.rb
@@ -93,6 +93,48 @@ describe '#make_database_queries' do
         end
       end
     end
+
+    context 'when a `manipulative` option is as true' do
+      context 'and there is a create query' do
+        subject { Cat.create }
+
+        it 'matches true' do
+          expect { subject }.to make_database_queries(manipulative: true)
+        end
+      end
+
+      context 'and there is an update query' do
+        before do
+          Cat.create if Cat.count == 0
+        end
+
+        subject { Cat.last.update name: 'Felix' }
+
+        it 'matches true' do
+          expect { subject }.to make_database_queries(manipulative: true)
+        end
+      end
+
+      context 'and there is a destroy query' do
+        before do
+          Cat.create if Cat.count == 0
+        end
+
+        subject { Cat.last.destroy }
+
+        it 'matches true' do
+          expect { subject }.to make_database_queries(manipulative: true)
+        end
+      end
+
+      context 'and there are no manipulative queries' do
+        it 'raises an error' do
+          expect do
+            expect { subject }.to make_database_queries(manipulative: true)
+          end.to raise_error
+        end
+      end
+    end
   end
 
   context 'when no queries are made' do


### PR DESCRIPTION
The gem was pretty much what I was looking for, except that I need to know when the database is actually manipulated.
