### PR TITLE
Restore Rspec 2 support

### DIFF
--- a/lib/db_query_matchers/make_database_queries.rb
+++ b/lib/db_query_matchers/make_database_queries.rb
@@ -15,7 +15,21 @@ require 'rspec/mocks'
 #
 # @see DBQueryMatchers::QueryCounter
 RSpec::Matchers.define :make_database_queries do |options = {}|
-  supports_block_expectations
+  if RSpec::Core::Version::STRING =~ /^2/
+    def self.failure_message_when_negated(&block)
+      failure_message_for_should_not(&block)
+    end
+
+    def self.failure_message(&block)
+      failure_message_for_should(&block)
+    end
+
+    def supports_block_expectations?
+      true
+    end
+  else
+    supports_block_expectations
+  end
 
   # Taken from ActionView::Helpers::TextHelper
   def pluralize(count, singular, plural = nil)


### PR DESCRIPTION
It seems simple to restore support for RSpec 2 without messing up the matcher code too much. 
