### PR TITLE
 Matcher change_database_queries_count is implemented

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,20 @@ describe 'MyCode' do
       expect { subject.make_special_queries }.to make_database_queries(matching: /DELETE/)
     end
   end
+
+  it 'matches when there is an N+1 redundancy' do
+    Post.create!(author: Author.create!)
+    expect do
+      Post.create!(author: Author.create!)
+    end.to change_database_queries_count(by: 1) { Post.all.each(&:author) }
+  end
+
+  it 'matches when there is no N+1 redundancy' do
+    Post.create!(author: Author.create!)
+    expect do
+      Post.create!(author: Author.create!)
+    end.not_to change_database_queries_count(by: 1) { Post.includes(:author).each(&:author) }
+  end
 end
 ```
 

--- a/db-query-matchers.gemspec
+++ b/db-query-matchers.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'activesupport', '>= 4.0', "<= 6.0"
   spec.add_runtime_dependency 'rspec', '~> 3.0'
+  spec.add_runtime_dependency 'diffy'
 
   spec.add_development_dependency 'activerecord',  '>= 4.0', "<= 6.0"
   spec.add_development_dependency 'sqlite3'

--- a/lib/db_query_matchers.rb
+++ b/lib/db_query_matchers.rb
@@ -1,4 +1,6 @@
 require 'db_query_matchers/version'
+require 'diffy'
+require 'db_query_matchers/change_database_queries_count'
 require 'db_query_matchers/make_database_queries'
 require 'db_query_matchers/query_counter'
 require 'db_query_matchers/configuration'

--- a/lib/db_query_matchers/change_database_queries_count.rb
+++ b/lib/db_query_matchers/change_database_queries_count.rb
@@ -1,0 +1,71 @@
+require 'rspec/core'
+require 'rspec/expectations'
+
+# Can be used to spec N+1 redundancies.
+#
+# @example
+#   expect { Post.create! }.to change_database_queries_count(by: 1) { Post.all.each(&:comments) }
+#
+# @example
+#   expect { Post.create! }.not_to change_database_queries_count { Post.includes(:comments).each(&:comments) }
+#
+# @see DBQueryMatchers::QueryCounter
+RSpec::Matchers.define :change_database_queries_count do |options = {}|
+  if RSpec::Core::Version::STRING =~ /^2/
+    def self.failure_message_when_negated(&block)
+      failure_message_for_should_not(&block)
+    end
+
+    def self.failure_message(&block)
+      failure_message_for_should(&block)
+    end
+
+    def supports_block_expectations?
+      true
+    end
+  else
+    supports_block_expectations
+  end
+
+  def diff
+    Diffy::Diff.new(@before_counter.log.join("\n") + "\n", @after_counter.log.join("\n") + "\n")
+  end
+
+  define_method :matches? do |subject|
+    @before_counter = DBQueryMatchers::QueryCounter.new(options)
+    @after_counter = DBQueryMatchers::QueryCounter.new(options)
+    ActiveSupport::Notifications
+      .subscribed(@before_counter.to_proc, DBQueryMatchers.configuration.db_event, &block_arg)
+    subject.call
+    ActiveSupport::Notifications
+      .subscribed(@after_counter.to_proc, DBQueryMatchers.configuration.db_event, &block_arg)
+
+    if options[:by]
+      options[:by] == @after_counter.count - @before_counter.count
+    else
+      @before_counter.count != @after_counter.count
+    end
+  end
+
+  failure_message_when_negated do |_|
+    fail if options[:by]
+    <<-EOS
+expected the same number of queries to be made, but #{@before_counter.count} has changed to #{@after_counter.count}:
+#{diff}
+    EOS
+  end
+
+  failure_message do |_|
+    if options[:by]
+      <<-EOS
+expected the number of queries to change by #{options[:by]}, but it has changed by #{@after_counter.count - @before_counter.count}:
+#{diff}
+      EOS
+    else
+      <<-EOS
+expected the number of queries to change, but it has not changed:
+#{diff}
+      EOS
+    end
+  end
+end

--- a/lib/db_query_matchers/make_database_queries.rb
+++ b/lib/db_query_matchers/make_database_queries.rb
@@ -42,20 +42,7 @@ RSpec::Matchers.define :make_database_queries do |options = {}|
   end
 
   define_method :matches? do |block|
-    counter_options = {}
-    if options[:manipulative]
-      counter_options[:matches] = [/^\ *(INSERT|UPDATE|DELETE\ FROM)/]
-    end
-    if options[:matching]
-      counter_options[:matches] ||= []
-      case options[:matching]
-      when Regexp
-        counter_options[:matches] << options[:matching]
-      when String
-        counter_options[:matches] << Regexp.new(Regexp.escape(options[:matching]))
-      end
-    end
-    @counter = DBQueryMatchers::QueryCounter.new(counter_options)
+    @counter = DBQueryMatchers::QueryCounter.new(options)
     ActiveSupport::Notifications.subscribed(@counter.to_proc,
                                             DBQueryMatchers.configuration.db_event,
                                             &block)

--- a/lib/db_query_matchers/query_counter.rb
+++ b/lib/db_query_matchers/query_counter.rb
@@ -17,7 +17,18 @@ module DBQueryMatchers
     attr_reader :count, :log
 
     def initialize(options = {})
-      @matches = options[:matches]
+      if options[:manipulative]
+        @matches = [/^\ *(INSERT|UPDATE|DELETE\ FROM)/]
+      end
+      if options[:matching]
+        @matches ||= []
+        case options[:matching]
+        when Regexp
+          @matches << options[:matching]
+        when String
+          @matches << Regexp.new(Regexp.escape(options[:matching]))
+        end
+      end
       @count = 0
       @log   = []
     end

--- a/spec/db_query_matchers/change_database_queries_count_spec.rb
+++ b/spec/db_query_matchers/change_database_queries_count_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+describe '#change_database_queries_count' do
+  before do
+    Post.destroy_all
+    Author.destroy_all
+  end
+
+  it 'matches when there is an N+1 redundancy' do
+    Post.create!(author: Author.create!)
+    expect do
+      Post.create!(author: Author.create!)
+    end.to change_database_queries_count(by: 1) { Post.all.each(&:author) }
+  end
+
+  it 'raises an error when there is no N+1 redundancy' do
+    Post.create!(author: Author.create!)
+    expect do
+      expect do
+        Post.create!(author: Author.create!)
+      end.not_to change_database_queries_count { Post.all.each(&:author) }
+    end.to raise_error(RSpec::Expectations::ExpectationNotMetError,
+      /\+SELECT/)
+  end
+
+  it 'matches when there is no N+1 redundancy' do
+    Post.create!(author: Author.create!)
+    expect do
+      Post.create!(author: Author.create!)
+    end.not_to change_database_queries_count(by: 1) { Post.includes(:author).each(&:author) }
+  end
+
+  it 'raises an error when there is an N+1 redundancy' do
+    Post.create!(author: Author.create!)
+    expect do
+      expect do
+        Post.create!(author: Author.create!)
+      end.to change_database_queries_count { Post.includes(:author).each(&:author) }
+    end.to raise_error(RSpec::Expectations::ExpectationNotMetError,
+      /\+SELECT/)
+  end
+end

--- a/spec/db_query_matchers/make_database_queries_spec.rb
+++ b/spec/db_query_matchers/make_database_queries_spec.rb
@@ -157,13 +157,21 @@ describe '#make_database_queries' do
 
       context 'and there is an update query' do
         before do
-          Cat.create if Cat.count == 0
+          Cat.destroy_all
+          Cat.create
         end
 
         subject { Cat.last.update name: 'Felix' }
 
         it 'matches true' do
           expect { subject }.to make_database_queries(manipulative: true)
+        end
+
+        it 'logs binds when match fails' do
+          expect do
+            expect { subject }.not_to make_database_queries(manipulative: true)
+          end.to raise_error(RSpec::Expectations::ExpectationNotMetError,
+            /["name", "Felix"]/)
         end
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,5 +13,11 @@ RSpec.configure do |config|
     create_table :cats, :force => true do |t|
       t.column :name, :string
     end
+
+    create_table :authors, :force => true
+
+    create_table :posts, :force => true do |t|
+      t.references :author
+    end
   end
 end

--- a/spec/support/models/author.rb
+++ b/spec/support/models/author.rb
@@ -1,0 +1,4 @@
+# Test model
+class Author < ActiveRecord::Base
+  has_many :posts
+end

--- a/spec/support/models/post.rb
+++ b/spec/support/models/post.rb
@@ -1,0 +1,4 @@
+# Test model
+class Post < ActiveRecord::Base
+  belongs_to :author
+end


### PR DESCRIPTION
Hello. This matcher can be useful when spec'ing N+1 redundancies:

```ruby
  it 'matches when there is an N+1 redundancy' do
    Post.create!(author: Author.create!)
    expect do
      Post.create!(author: Author.create!)
    end.to change_database_queries_count(by: 1) { Post.all.each(&:author) }
  end

  it 'matches when there is no N+1 redundancy' do
    Post.create!(author: Author.create!)
    expect do
      Post.create!(author: Author.create!)
    end.not_to change_database_queries_count(by: 1) { Post.includes(:author).each(&:author) }
  end
```