### PR TITLE
Relax dependencies for Rails master compatibility

### DIFF
--- a/db-query-matchers.gemspec
+++ b/db-query-matchers.gemspec
@@ -15,10 +15,10 @@ Gem::Specification.new do |spec|
   spec.files         = Dir['lib/**/*.rb']
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'activesupport', '>= 4.0', "<= 6.0"
+  spec.add_runtime_dependency 'activesupport', '>= 4.0', "< 6.1"
   spec.add_runtime_dependency 'rspec', '~> 3.0'
 
-  spec.add_development_dependency 'activerecord',  '>= 4.0', "<= 6.0"
+  spec.add_development_dependency 'activerecord',  '>= 4.0', "< 6.1"
   spec.add_development_dependency 'sqlite3'
   spec.add_development_dependency "appraisal", "~> 2.0"
 


### PR DESCRIPTION
Rails 6.0 was recently released, and the version on the master branch is now [6.1.0.alpha](https://github.com/rails/rails/blob/f5943abcd0c5f15fb97356ca52ce49eb9fcb2dbc/RAILS_VERSION). The upper bound on these dependencies currently prevents applications using this gem from running against Rails master.