### PR TITLE
Allow SELECT queries without a WHERE or LIMIT to be tested with the unscoped option

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ describe 'MyCode' do
     end
   end
 
+  context 'when we only care about unscoped queries (SELECT without a WHERE or LIMIT clause))' do
+    it 'makes an unscoped database query' do
+      expect { subject.make_one_query }.to make_database_queries(unscoped: true)
+    end
+  end
+
   context 'when we only care about queries matching a certain pattern' do
     it 'makes a destructive database query' do
       expect { subject.make_special_queries }.to make_database_queries(matching: 'DELETE * FROM')

--- a/lib/db_query_matchers/make_database_queries.rb
+++ b/lib/db_query_matchers/make_database_queries.rb
@@ -12,6 +12,9 @@ require 'rspec/expectations'
 # @example
 #   expect { subject }.to make_database_queries(manipulative: true)
 #
+# @example
+#   expect { subject }.to make_database_queries(unscoped: true)
+#
 # @see DBQueryMatchers::QueryCounter
 RSpec::Matchers.define :make_database_queries do |options = {}|
   if RSpec::Core::Version::STRING =~ /^2/
@@ -45,6 +48,9 @@ RSpec::Matchers.define :make_database_queries do |options = {}|
     counter_options = {}
     if options[:manipulative]
       counter_options[:matches] = [/^\ *(INSERT|UPDATE|DELETE\ FROM)/]
+    end
+    if options[:unscoped]
+      counter_options[:matches] = [/^ SELECT(?!\sCOUNT).*FROM(?!.*(WHERE|LIMIT))/mx]
     end
     if options[:matching]
       counter_options[:matches] ||= []

--- a/lib/db_query_matchers/make_database_queries.rb
+++ b/lib/db_query_matchers/make_database_queries.rb
@@ -50,7 +50,16 @@ RSpec::Matchers.define :make_database_queries do |options = {}|
       counter_options[:matches] = [/^\ *(INSERT|UPDATE|DELETE\ FROM)/]
     end
     if options[:unscoped]
-      counter_options[:matches] = [/^ SELECT(?!\sCOUNT).*FROM(?!.*(WHERE|LIMIT))/mx]
+      counter_options[:matches] = [
+        %r{
+          (?:                         # Any of these appear
+            SELECT(?!\sCOUNT).*FROM|  #   SELECT ... FROM (not SELECT ... COUNT)
+            DELETE\sFROM|             #   DELETE ... FROM
+            UPDATE.*SET               #   UPDATE ... SET
+          )
+          (?!.*(WHERE|LIMIT))         # Followed by WHERE and/or LIMIT
+        }mx                           # Ignore whitespace and newlines
+      ]
     end
     if options[:matching]
       counter_options[:matches] ||= []

--- a/spec/db_query_matchers/make_database_queries_spec.rb
+++ b/spec/db_query_matchers/make_database_queries_spec.rb
@@ -189,6 +189,50 @@ describe '#make_database_queries' do
       end
     end
 
+    context 'when a `unscoped` option is as true' do
+      shared_examples 'it raises an error' do
+        it 'raises an error' do
+          expect do
+            expect { subject }.to make_database_queries(unscoped: true)
+          end.to raise_error(RSpec::Expectations::ExpectationNotMetError,
+                             /expected queries, but none were made/)
+        end
+
+        it 'does not raise with `to_not`' do
+          expect { subject }.to_not make_database_queries(unscoped: true)
+        end
+      end
+
+      before do
+        Cat.create if Cat.count == 0
+      end
+
+      context 'and there is a query without a WHERE or LIMIT clause' do
+        subject { Cat.all.to_a }
+
+        it 'matches true' do
+          expect { subject }.to make_database_queries(unscoped: true)
+        end
+
+        it 'raises an error with `to_not`' do
+          expect do
+            expect { subject }.to_not make_database_queries(unscoped: true)
+          end.to raise_error(RSpec::Expectations::ExpectationNotMetError,
+                             /expected no queries, but 1 were made/)
+        end
+      end
+
+      context 'there is a limit clause' do
+        subject { Cat.all.limit(100).to_a }
+        include_examples 'it raises an error'
+      end
+
+      context 'there is a where clause' do
+        subject { Cat.where(name: 'bob').to_a }
+        include_examples 'it raises an error'
+      end
+    end
+
     context 'when a `matching` option is specified' do
       context 'with a string matcher' do
         context 'and there is a query matching the matcher specified' do

--- a/spec/db_query_matchers/make_database_queries_spec.rb
+++ b/spec/db_query_matchers/make_database_queries_spec.rb
@@ -189,7 +189,7 @@ describe '#make_database_queries' do
       end
     end
 
-    context 'when a `unscoped` option is as true' do
+    context 'when a `unscoped` option is true' do
       shared_examples 'it raises an error' do
         it 'raises an error' do
           expect do
@@ -208,28 +208,156 @@ describe '#make_database_queries' do
       end
 
       context 'and there is a query without a WHERE or LIMIT clause' do
-        subject { Cat.all.to_a }
+        context 'SELECT' do
+          subject { Cat.all.to_a }
 
-        it 'matches true' do
-          expect { subject }.to make_database_queries(unscoped: true)
+          it 'matches true' do
+            expect { subject }.to make_database_queries(unscoped: true)
+          end
+
+          it 'raises an error with `to_not`' do
+            expect do
+              expect { subject }.to_not make_database_queries(unscoped: true)
+            end.to raise_error(RSpec::Expectations::ExpectationNotMetError,
+                               /expected no queries, but 1 were made/)
+          end
         end
 
-        it 'raises an error with `to_not`' do
-          expect do
-            expect { subject }.to_not make_database_queries(unscoped: true)
-          end.to raise_error(RSpec::Expectations::ExpectationNotMetError,
-                             /expected no queries, but 1 were made/)
+        context 'DELETE' do
+          subject { Cat.delete_all }
+
+          it 'matches true' do
+            expect { subject }.to make_database_queries(unscoped: true)
+          end
+
+          it 'raises an error with `to_not`' do
+            expect do
+              expect { subject }.to_not make_database_queries(unscoped: true)
+            end.to raise_error(RSpec::Expectations::ExpectationNotMetError,
+                               /expected no queries, but 1 were made/)
+          end
+        end
+
+        context 'UPDATE' do
+          subject { Cat.update_all(name: 'Nombre') }
+
+          it 'matches true' do
+            expect { subject }.to make_database_queries(unscoped: true)
+          end
+
+          it 'raises an error with `to_not`' do
+            expect do
+              expect { subject }.to_not make_database_queries(unscoped: true)
+            end.to raise_error(RSpec::Expectations::ExpectationNotMetError,
+                               /expected no queries, but 1 were made/)
+          end
+        end
+
+        context 'INSERT' do
+          context 'without INTO SELECT' do
+            subject { Cat.create name: 'Joe' }
+
+            it 'matches false' do
+              expect { subject }.to_not make_database_queries(unscoped: true)
+            end
+          end
+
+          context 'with INTO SELECT' do
+            subject do
+              Cat.connection.execute <<-SQL
+                INSERT INTO "cats" SELECT * FROM "dogs";
+              SQL
+            end
+            it 'matches true' do
+              expect { subject }.to make_database_queries(unscoped: true)
+            end
+
+            it 'raises an error with `to`' do
+              expect do
+                expect { subject }.to_not make_database_queries(unscoped: true)
+              end.to raise_error(RSpec::Expectations::ExpectationNotMetError,
+                                 /expected no queries, but 1 were made/)
+            end
+          end
         end
       end
 
       context 'there is a limit clause' do
-        subject { Cat.all.limit(100).to_a }
-        include_examples 'it raises an error'
+        context 'SELECT' do
+          subject { Cat.all.limit(100).to_a }
+          include_examples 'it raises an error'
+        end
+
+        context 'UPDATE' do
+          subject { Cat.limit(10).update_all(name: 'Nombre') }
+          include_examples 'it raises an error'
+        end
+
+        context 'DELETE' do
+          subject { Cat.limit(100).delete_all }
+          include_examples 'it raises an error'
+        end
+
+        context 'INTO SELECT' do
+          subject do
+            Cat.connection.execute <<-SQL
+              INSERT INTO "cats" SELECT * FROM "dogs" LIMIT 100;
+            SQL
+          end
+          include_examples 'it raises an error'
+        end
       end
 
       context 'there is a where clause' do
-        subject { Cat.where(name: 'bob').to_a }
-        include_examples 'it raises an error'
+        context 'SELECT' do
+          subject { Cat.where(name: 'Bob').to_a }
+          include_examples 'it raises an error'
+        end
+
+        context 'UPDATE' do
+          subject { Cat.where(name: 'Bob').update_all(name: 'Nombre') }
+          include_examples 'it raises an error'
+        end
+
+        context 'DELETE' do
+          subject { Cat.where(name: 'Bob').delete_all }
+          include_examples 'it raises an error'
+        end
+
+        context 'INTO SELECT' do
+          subject do
+            Cat.connection.execute <<-SQL
+              INSERT INTO "cats" SELECT * FROM "dogs" WHERE "dogs"."name" = 'Fido';
+            SQL
+          end
+          include_examples 'it raises an error'
+        end
+      end
+
+      context 'there is a where and limit clause' do
+        context 'SELECT' do
+          subject { Cat.where(name: 'Bob').limit(10).to_a }
+          include_examples 'it raises an error'
+        end
+
+        context 'UPDATE' do
+          subject { Cat.where(name: 'Bob').limit(10).update_all(name: 'Nombre') }
+          include_examples 'it raises an error'
+        end
+
+        context 'DELETE' do
+          subject { Cat.where(name: 'Bob').limit(10).delete_all }
+          include_examples 'it raises an error'
+        end
+
+        context 'INTO SELECT' do
+          subject do
+            Cat.connection.execute <<-SQL
+              INSERT INTO "cats" SELECT * FROM "dogs" WHERE "dogs"."name" = 'Fido' LIMIT 10;
+            SQL
+          end
+          include_examples 'it raises an error'
+        end
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,5 +13,9 @@ RSpec.configure do |config|
     create_table :cats, :force => true do |t|
       t.column :name, :string
     end
+
+    create_table :dogs, :force => true do |t|
+      t.column :name, :string
+    end
   end
 end

--- a/spec/support/models/cat.rb
+++ b/spec/support/models/cat.rb
@@ -1,4 +1,4 @@
-# Test model
-class Cat < ActiveRecord::Base
+# Test models
+class Cat < ActiveRecord::Base; end
+class Dog < ActiveRecord::Base; end
 
-end


### PR DESCRIPTION
I've found the `unscoped: true` option here to be useful in identifying SELECT queries which are not scoped. In a large application, loading all objects using ActiveRecord is bad, and this tests for it.

If you accept this idea and you're looking for additional maintainers to help get this merged and a gem cut, I'm interested in helping.