### PR TITLE
Use String matching operator (=~) in #pluralize

### DIFF
--- a/lib/db_query_matchers/make_database_queries.rb
+++ b/lib/db_query_matchers/make_database_queries.rb
@@ -35,7 +35,7 @@ RSpec::Matchers.define :make_database_queries do |options = {}|
 
   # Taken from ActionView::Helpers::TextHelper
   def pluralize(count, singular, plural = nil)
-    word = if count == 1 || count =~ /^1(\.0+)?$/
+    word = if count == 1 || count.to_s =~ /^1(\.0+)?$/
              singular
            else
              plural || singular.pluralize


### PR DESCRIPTION
The matching operator on Object has been deprecated and will always return nil, throwing up a warning message (cf.: https://ruby-doc.org/core-2.7.1/Object.html#method-i-3D-7E).  This change will make the comment honest and harmonize it with ActionView::Helpers::TextHelper.