### PR TITLE
Check queries against primary or replica by role in Rails 6+

### DIFF
--- a/lib/db_query_matchers/make_database_queries.rb
+++ b/lib/db_query_matchers/make_database_queries.rb
@@ -69,6 +69,11 @@ RSpec::Matchers.define :make_database_queries do |options = {}|
         counter_options[:matches] << Regexp.new(Regexp.escape(options[:matching]))
       end
     end
+
+    if options[:database_role]
+      counter_options[:database_role] = options[:database_role]
+    end
+
     @counter = DBQueryMatchers::QueryCounter.new(counter_options)
     ActiveSupport::Notifications.subscribed(@counter.to_proc,
                                             DBQueryMatchers.configuration.db_event,

--- a/lib/db_query_matchers/query_counter.rb
+++ b/lib/db_query_matchers/query_counter.rb
@@ -18,6 +18,7 @@ module DBQueryMatchers
 
     def initialize(options = {})
       @matches = options[:matches]
+      @database_role = options[:database_role]
       @count = 0
       @log   = []
     end
@@ -39,6 +40,9 @@ module DBQueryMatchers
     # @param _message_id [String] unique ID for this notification
     # @param payload    [Hash]   the payload
     def callback(_name, _start,  _finish, _message_id, payload)
+      if @database_role
+        return if ActiveRecord::Base.current_role != database_role
+      end
       return if @matches && !any_match?(@matches, payload[:sql])
       return if any_match?(DBQueryMatchers.configuration.ignores, payload[:sql])
       return if DBQueryMatchers.configuration.ignore_cached && payload[:cached]

--- a/spec/db_query_matchers/make_database_queries_spec.rb
+++ b/spec/db_query_matchers/make_database_queries_spec.rb
@@ -518,6 +518,28 @@ describe '#make_database_queries' do
     end
   end
 
+  if Gem::Version.new(ActiveRecord::VERSION::STRING) >= Gem::Version.new('6.0.0')
+    context 'when a database_role is used' do
+      subject { Cat.first }
+
+      it 'matches true when the matching database role was used' do
+        expect do
+          ActiveRecord::Base.connected_to(role: :reading) do
+            subject
+          end
+        end.to make_database_queries(database_role: :reading)
+      end
+
+      it 'matches false when a non-matching database role was used' do
+        expect do
+          ActiveRecord::Base.connected_to(role: :reading) do
+            subject
+          end
+        end.to make_database_queries(database_role: :writing)
+      end
+    end
+  end
+
   context 'when no queries are made' do
     subject { 'hi' }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,10 @@ require 'active_record'
 Dir[File.dirname(__FILE__) + '/support/**/*.rb'].each { |f| require f }
 
 RSpec.configure do |config|
+  if Gem::Version.new(ActiveRecord::VERSION::STRING) >= Gem::Version.new('6.0.0')
+    ActiveRecord::Base.connects_to database: { writing: :primary, reading: :replica }
+  end
+
   ActiveRecord::Base.establish_connection adapter:  'sqlite3',
                                           database: ':memory:'
 


### PR DESCRIPTION
This is a reimplementation of #35, which was reverted due to an
unrelated conflict.

This change updates the query matchers to allow verification that
queries ran against the primary or replica database. This can be useful
in Rails 6 to verify the database role that was used, as test suites in
Rails by default group all database use under a single connection. The
role is still correctly set in test, allowing us to check that we made
queries against the correct role.
