### PR TITLE
Add Ruby 3.1 to the CI matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,9 +17,9 @@ jobs:
         experimental: [false]
 
         include:
-          - ruby-version: 'head'
-            gemfile: rails_6_0
-            experimental: true
+          - ruby-version: '3.1'
+            gemfile: rails_7_0
+            experimental: false
           - ruby-version: 'head'
             gemfile: rails_6_1
             experimental: true
@@ -30,6 +30,9 @@ jobs:
             gemfile: rails_edge
             experimental: true
           - ruby-version: '3.0'
+            gemfile: rails_edge
+            experimental: true
+          - ruby-version: '3.1'
             gemfile: rails_edge
             experimental: true
           - ruby-version: 'head'


### PR DESCRIPTION
Also removes ruby-head / Rails 6.0, since that isn't a technically supported combination by the Rails team.