### PR TITLE
Add `database_role` option to scope checks for replicas

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         ruby-version: ['2.5', '2.6', '2.7', '3.0']
-        gemfile: [ rails_5_2, rails_6_0, rails_6_1, rails_7_0 ]
+        gemfile: [ rails_5_2, rails_6_0, rails_6_1, rails_7_0, rails_7_1 ]
         experimental: [false]
 
         include:
@@ -41,6 +41,12 @@ jobs:
 
         exclude:
           - ruby-version: '2.5'
+            gemfile: rails_7_1
+          - ruby-version: '2.6'
+            gemfile: rails_7_1
+          - ruby-version: '2.7'
+            gemfile: rails_7_1
+          - ruby-version: '2.5'
             gemfile: rails_7_0
           - ruby-version: '2.6'
             gemfile: rails_7_0
@@ -48,6 +54,7 @@ jobs:
             gemfile: rails_5_2
           - ruby-version: '3.0'
             gemfile: rails_5_2
+
 
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile

--- a/Appraisals
+++ b/Appraisals
@@ -52,8 +52,14 @@ appraise "rails_7_0" do
   gem "sqlite3", "~> 1.4"
 end
 
+appraise "rails_7_1" do
+  version = "~> 7.1.0"
+  gem "activesupport", version
+  gem "sqlite3", ">= 1.4"
+end
+
 appraise "rails_edge" do
   gem "activerecord", github: 'rails/rails'
   gem "activesupport", github: 'rails/rails'
-  gem "sqlite3", "~> 1.4"
+  gem "sqlite3", ">= 1.4"
 end

--- a/db-query-matchers.gemspec
+++ b/db-query-matchers.gemspec
@@ -15,10 +15,10 @@ Gem::Specification.new do |spec|
   spec.files         = Dir['lib/**/*.rb']
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'activesupport', '>= 4.0', "< 7.1"
+  spec.add_runtime_dependency 'activesupport', '>= 4.0', "< 7.2"
   spec.add_runtime_dependency 'rspec', '>= 3.0'
 
-  spec.add_development_dependency 'activerecord',  '>= 4.0', "< 7.1"
+  spec.add_development_dependency 'activerecord',  '>= 4.0', "< 7.2"
   spec.add_development_dependency 'sqlite3'
   spec.add_development_dependency "appraisal", "~> 2.0"
 

--- a/gemfiles/rails_6_1.gemfile
+++ b/gemfiles/rails_6_1.gemfile
@@ -3,6 +3,5 @@
 source "https://rubygems.org"
 
 gem "activesupport", "~> 6.1.0"
-gem "sqlite3", "~> 1.4"
 
 gemspec path: "../"

--- a/gemfiles/rails_7_0.gemfile
+++ b/gemfiles/rails_7_0.gemfile
@@ -3,6 +3,5 @@
 source "https://rubygems.org"
 
 gem "activesupport", "~> 7.0.0"
-gem "sqlite3", "~> 1.4"
 
 gemspec path: "../"

--- a/gemfiles/rails_7_1.gemfile
+++ b/gemfiles/rails_7_1.gemfile
@@ -2,8 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "activerecord", github: "rails/rails"
-gem "activesupport", github: "rails/rails"
+gem "activesupport", "~> 7.1.0"
 gem "sqlite3", ">= 1.4"
 
 gemspec path: "../"

--- a/gemfiles/rails_edge.gemfile
+++ b/gemfiles/rails_edge.gemfile
@@ -4,6 +4,5 @@ source "https://rubygems.org"
 
 gem "activerecord", github: "rails/rails"
 gem "activesupport", github: "rails/rails"
-gem "sqlite3", "~> 1.4"
 
 gemspec path: "../"

--- a/lib/db_query_matchers/make_database_queries.rb
+++ b/lib/db_query_matchers/make_database_queries.rb
@@ -69,6 +69,8 @@ RSpec::Matchers.define :make_database_queries do |options = {}|
         counter_options[:matches] << Regexp.new(Regexp.escape(options[:matching]))
       end
     end
+
+    counter_options[:database_role] = options[:database_role]
     @counter = DBQueryMatchers::QueryCounter.new(counter_options)
     ActiveSupport::Notifications.subscribed(@counter.to_proc,
                                             DBQueryMatchers.configuration.db_event,

--- a/lib/db_query_matchers/query_counter.rb
+++ b/lib/db_query_matchers/query_counter.rb
@@ -18,6 +18,7 @@ module DBQueryMatchers
 
     def initialize(options = {})
       @matches = options[:matches]
+      @database_role = options[:database_role]
       @count = 0
       @log   = []
     end
@@ -39,6 +40,7 @@ module DBQueryMatchers
     # @param _message_id [String] unique ID for this notification
     # @param payload    [Hash]   the payload
     def callback(_name, _start,  _finish, _message_id, payload)
+      return if @database_role && (ActiveRecord::Base.current_role != @database_role)
       return if @matches && !any_match?(@matches, payload[:sql])
       return if any_match?(DBQueryMatchers.configuration.ignores, payload[:sql])
       return if DBQueryMatchers.configuration.ignore_cached && payload[:cached]

--- a/spec/db_query_matchers/make_database_queries_spec.rb
+++ b/spec/db_query_matchers/make_database_queries_spec.rb
@@ -417,6 +417,27 @@ describe '#make_database_queries' do
       end
     end
 
+    if ActiveRecord::VERSION::MAJOR > 6 ||
+        (ActiveRecord::VERSION::MAJOR == 6 && ActiveRecord::VERSION::MINOR > 0)
+      context 'when the database_role option is used' do
+        context 'and a query is using the specified role' do
+          subject { Cat.create }
+          it 'matches true' do
+            expect { subject }.to make_database_queries(database_role: :writing)
+          end
+        end
+
+        context 'and no queries are made matching the role' do
+          it 'raises an error' do
+            expect do
+              expect { subject }.to make_database_queries(database_role: :reading)
+            end.to raise_error(RSpec::Expectations::ExpectationNotMetError,
+                    /expected queries, but none were made/)
+          end
+        end
+      end
+    end
+
     context 'when a `schemaless` option is true' do
       before do
         DBQueryMatchers.configure do |config|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,8 +4,14 @@ require 'active_record'
 Dir[File.dirname(__FILE__) + '/support/**/*.rb'].each { |f| require f }
 
 RSpec.configure do |config|
-  ActiveRecord::Base.establish_connection adapter:  'sqlite3',
-                                          database: ':memory:'
+  if ActiveRecord::VERSION::MAJOR > 5
+    ActiveRecord::Base.establish_connection adapter:  'sqlite3',
+                                            database: ':memory:',
+                                            role: :writing
+  else
+    ActiveRecord::Base.establish_connection adapter:  'sqlite3',
+                                            database: ':memory:'
+  end
 
   ActiveRecord::Schema.define do
     self.verbose = false


### PR DESCRIPTION
It can be useful to confirm that certain database queries are being 
made against a primary database or a replica database. This change 
adds a new option `database_role`, which makes the query counter only 
count queries that were made against a database with the specified 
role.

We've used this logic at CommonLit for several years to ensure we're
querying the right database. This works in test environments even if
your primary and replica database configurations point at the same
database.

This is a retry at the work in #51. CI is failing on Rails Edge, but 
it doesn't look related to the changes as far as I can tell.