### PR TITLE
Drop support for EOL software

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,49 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.5', '2.6', '2.7', '3.0']
-        gemfile: [ rails_5_2, rails_6_0, rails_6_1, rails_7_0, rails_7_1 ]
+        ruby-version: ['3.0', '3.1', '3.2']
+        gemfile: [ rails_6_1, rails_7_0, rails_7_1 ]
         experimental: [false]
-
-        include:
-          - ruby-version: '3.1'
-            gemfile: rails_7_0
-            experimental: false
-          - ruby-version: 'head'
-            gemfile: rails_6_1
-            experimental: true
-          - ruby-version: 'head'
-            gemfile: rails_7_0
-            experimental: true
-          - ruby-version: '2.7'
-            gemfile: rails_edge
-            experimental: true
-          - ruby-version: '3.0'
-            gemfile: rails_edge
-            experimental: true
-          - ruby-version: '3.1'
-            gemfile: rails_edge
-            experimental: true
-          - ruby-version: 'head'
-            gemfile: rails_edge
-            experimental: true
-
-        exclude:
-          - ruby-version: '2.5'
-            gemfile: rails_7_1
-          - ruby-version: '2.6'
-            gemfile: rails_7_1
-          - ruby-version: '2.7'
-            gemfile: rails_7_1
-          - ruby-version: '2.5'
-            gemfile: rails_7_0
-          - ruby-version: '2.6'
-            gemfile: rails_7_0
-          - ruby-version: '2.7'
-            gemfile: rails_5_2
-          - ruby-version: '3.0'
-            gemfile: rails_5_2
-
 
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile

--- a/db-query-matchers.gemspec
+++ b/db-query-matchers.gemspec
@@ -22,5 +22,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'sqlite3'
   spec.add_development_dependency "appraisal", "~> 2.0"
 
-  spec.required_ruby_version = ">= 1.9.2"
+  spec.required_ruby_version = ">= 3.0"
 end


### PR DESCRIPTION
Ruby 2.7 reached EOL in March 2023. Rails 6.0 reached EOL Aug 2019. Stop supporting old software.
