### PR TITLE
Remove upper limit for rails gems

### DIFF
--- a/db-query-matchers.gemspec
+++ b/db-query-matchers.gemspec
@@ -19,10 +19,10 @@ Gem::Specification.new do |spec|
   spec.files         = Dir['lib/**/*.rb']
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'activesupport', '>= 4.0', "< 8.1"
+  spec.add_runtime_dependency 'activesupport', '>= 4.0'
   spec.add_runtime_dependency 'rspec', '>= 3.0'
 
-  spec.add_development_dependency 'activerecord',  '>= 4.0', "< 8.1"
+  spec.add_development_dependency 'activerecord',  '>= 4.0'
   spec.add_development_dependency 'sqlite3'
   spec.add_development_dependency "appraisal", "~> 2.0"
 


### PR DESCRIPTION
Please rails 8.1 will be released in a week, and more and more companies are running on Rails edge/main as well.

could we normalize removing the upper limit on rails, and let people open issues if they ever use the rails latest version, or if maintainers of the gems add explicit support for newer versions, whichever comes first.

Thanks in advance!